### PR TITLE
Bug fix: Remove CSS font size for the editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
     <style type="text/css" media="screen">
         div.pg-editor {
             height: 50vh;
-            font-size: 14pt;
         }
     </style>
     <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ace.js"></script>

--- a/index.html
+++ b/index.html
@@ -53,13 +53,13 @@
                 <form class="navbar-form navbar-left">
                 <label>Font size</label>
                 <select class="pg-fontsize form-control">
-                    <option>8</option>
-                    <option>10</option>
-                    <option>12</option>
-                    <option>14</option>
-                    <option>16</option>
-                    <option>20</option>
-                    <option>24</option>
+                    <option value="8">8</option>
+                    <option value="10">10</option>
+                    <option value="12">12</option>
+                    <option value="14">14</option>
+                    <option value="16">16</option>
+                    <option value="20">20</option>
+                    <option value="24">24</option>
                   </select>
                 </form>
                 <form class="navbar-form navbar-left">

--- a/index.js
+++ b/index.js
@@ -50,6 +50,13 @@ function init() {
     editor.getSession().setMode("ace/mode/golang");
     window.Editor = editor;
 
+    let fontSize = parseInt(getCookie("fontsize"), 10);
+    if (fontSize === 0) {
+        fontSize = 16;
+    }
+    document.querySelector('.pg-fontsize').value = fontSize;
+    editor.setFontSize(fontSize);
+
     setButtonsDisabled(true);
     if (window.location.hash) {
         var hash = window.location.hash.replace("#","");
@@ -62,19 +69,10 @@ function init() {
             })
         });
     } else {
-        Editor.setValue(defaultProg,-1);
+        Editor.setValue(defaultProg, -1);
         Go.Compile(defaultProg).then(() => {
             setButtonsDisabled(false);
         });
-    }
-
-    var fontsize = getCookie("fontsize");
-    if (fontsize != "") {
-        document.querySelector('.pg-fontsize').value = fontsize;
-        editor.setFontSize(+fontsize);
-    } else {
-        document.querySelector('.pg-fontsize').value = '16';
-        editor.setFontSize(16);
     }
 
     document.querySelector(".pg-fontsize").addEventListener("change", (e) => {

--- a/index.js
+++ b/index.js
@@ -48,10 +48,6 @@ function init() {
     editor.$blockScrolling = Infinity;
     editor.setTheme("ace/theme/sqlserver");
     editor.getSession().setMode("ace/mode/golang");
-
-    // Reset the font size other than 12 once so that
-    // setFontSize takes an effect with any numbers.
-    editor.setFontSize(10);
     window.Editor = editor;
 
     let fontSize = parseInt(getCookie("fontsize"), 10);

--- a/index.js
+++ b/index.js
@@ -50,13 +50,6 @@ function init() {
     editor.getSession().setMode("ace/mode/golang");
     window.Editor = editor;
 
-    let fontSize = parseInt(getCookie("fontsize"), 10);
-    if (fontSize === 0) {
-        fontSize = 16;
-    }
-    document.querySelector('.pg-fontsize').value = fontSize;
-    editor.setFontSize(fontSize);
-
     setButtonsDisabled(true);
     if (window.location.hash) {
         var hash = window.location.hash.replace("#","");
@@ -74,6 +67,13 @@ function init() {
             setButtonsDisabled(false);
         });
     }
+
+    let fontSize = parseInt(getCookie("fontsize"), 10);
+    if (fontSize === 0) {
+        fontSize = 16;
+    }
+    document.querySelector('.pg-fontsize').value = fontSize;
+    editor.setFontSize(fontSize);
 
     document.querySelector(".pg-fontsize").addEventListener("change", (e) => {
         e.preventDefault()

--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ function init() {
     editor.$blockScrolling = Infinity;
     editor.setTheme("ace/theme/sqlserver");
     editor.getSession().setMode("ace/mode/golang");
+
+    // Reset the font size other than 12 once so that
+    // setFontSize takes an effect with any numbers.
+    editor.setFontSize(10);
     window.Editor = editor;
 
     let fontSize = parseInt(getCookie("fontsize"), 10);


### PR DESCRIPTION
This PR fixes a problem that the editor's font size is not reset when the default program is used.